### PR TITLE
Fix Issue #1

### DIFF
--- a/AvantGarde/Projects/PathItem.cs
+++ b/AvantGarde/Projects/PathItem.cs
@@ -184,7 +184,7 @@ namespace AvantGarde.Projects
         /// </summary>
         public static string CleanPath(string path)
         {
-            if (Path.PathSeparator == '\\')
+            if (Path.DirectorySeparatorChar == '\\')
             {
                 return path.Trim().Replace('/', '\\');
             }


### PR DESCRIPTION
`PathSeparator` is used to separate paths in a list of paths sucha as what is inthe PATH environment variable. `DirectorySeparatorChar` is the **\\** or the **/** character.