### PR TITLE
Fix designer DLL not found when NUGET_PACKAGES is set

### DIFF
--- a/AvantGarde/Loading/RemoteLoader.cs
+++ b/AvantGarde/Loading/RemoteLoader.cs
@@ -158,10 +158,15 @@ namespace AvantGarde.Loading
             // ~/.nuget/packages/avalonia/<avalonia-version>/tools/netcoreapp2.0/designer/Avalonia.Designer.HostApp.dll
             if (!string.IsNullOrWhiteSpace(version))
             {
-                string src = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                string? src = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+                
+                if (string.IsNullOrEmpty(src))
+                {
+                    src = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                    src = Path.Combine(src, ".nuget");
+                    src = Path.Combine(src, "packages");
+                }
 
-                src = Path.Combine(src, ".nuget");
-                src = Path.Combine(src, "packages");
                 src = Path.Combine(src, "avalonia");
                 src = Path.Combine(src, version);
                 src = Path.Combine(src, "tools");


### PR DESCRIPTION
This fixes an issue where the Avalonia.Designer.HostApp.dll is not found when the default NuGet packages directory is changed.