### PR TITLE
Fixed loading of a solution when path contains spaces

### DIFF
--- a/AvantGarde/Views/MainWindow.axaml.cs
+++ b/AvantGarde/Views/MainWindow.axaml.cs
@@ -97,7 +97,7 @@ public partial class MainWindow : AvantWindow<MainWindowViewModel>
 
         if (paths?.Count > 0)
         {
-            OpenSolution(paths[0].Path.AbsolutePath);
+            OpenSolution(Uri.UnescapeDataString(paths[0].Path.AbsolutePath));
         }
     }
 


### PR DESCRIPTION
Hello, 

I encountered issue when the path to a solution contained spaces, both on Windows and Linux. I tested the fix on both platforms and it seems to be working.
![Error screenshot](https://github.com/kuiperzone/AvantGarde/assets/43780315/0a5c5c9f-b5bb-458f-9419-81727f5ec18d)
